### PR TITLE
Changed to use python-ldap exceptions

### DIFF
--- a/fakeldap.py
+++ b/fakeldap.py
@@ -29,6 +29,7 @@ import sys
 import logging
 import types
 from collections import defaultdict
+import ldap
 
 
 __version__ = "0.5.1"
@@ -70,11 +71,6 @@ class MockLDAP(object):
     MOD_ADD = 0
     MOD_DELETE = 1
     MOD_REPLACE = 2
-
-    class LDAPError(Exception): pass
-    class INVALID_CREDENTIALS(LDAPError): pass
-    class NO_SUCH_OBJECT(LDAPError): pass
-    class ALREADY_EXISTS(LDAPError): pass
 
     #
     # Submodules
@@ -288,7 +284,7 @@ class MockLDAP(object):
         if success:
             return (97, []) # python-ldap returns this; I don't know what it means
         else:
-            raise self.INVALID_CREDENTIALS('%s:%s' % (who, cred))
+            raise ldap.INVALID_CREDENTIALS('%s:%s' % (who, cred))
 
     def _compare_s(self, dn, attr, value):
         try:
@@ -333,7 +329,7 @@ class MockLDAP(object):
         try:
             entry = self.directory[dn]
         except KeyError:
-            raise self.NO_SUCH_OBJECT
+            raise ldap.NO_SUCH_OBJECT
 
         changes = newdn.split('=')
         newfulldn = '%s=%s,%s' % (changes[0], changes[1],
@@ -382,7 +378,7 @@ class MockLDAP(object):
         print entry
         try:
             self.directory[dn]
-            raise ALREADY_EXISTS
+            raise ldap.ALREADY_EXISTS
         except KeyError:
             self.directory[dn] = entry
             return (105,[], len(self.calls), [])

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 extra = {}
-requirements = [],
-tests_require = ['nose', 'Mock', 'coverage', 'unittest2']
+requirements = ['python-ldap'],
+tests_require = ['nose', 'Mock', 'coverage', 'unittest2', 'python-ldap']
 
 # In case we use python3
 if sys.version_info >= (3,):

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,6 @@
 from nose.tools import *
 from fakeldap import MockLDAP
+import ldap
 
 import unittest
 
@@ -28,7 +29,7 @@ class TestLdapOperations(unittest.TestCase):
 
         # Supply the wrong password
         assert_raises(
-            MockLDAP.INVALID_CREDENTIALS,
+            ldap.INVALID_CREDENTIALS,
             self.mock_ldap.simple_bind_s,
             who="cn=admin,dc=30loops,dc=net", cred="wrong"
         )


### PR DESCRIPTION
fakeldap was using exceptions that it defined internally.  When caller code substitutes the fakeldap for the real one in a test, it expects (and tries to catch) the authentic python-ldap exceptions to potentially be thrown, not the ones defined in fakeldap.

Therefore, I've changed fakeldap to throw the authentic exceptions as defined in python-ldap.

Cheers,
Gary
