### PR TITLE
Fixed a bug where ldap.NO_SUCH_OBJECT was used.

### DIFF
--- a/fakeldap.py
+++ b/fakeldap.py
@@ -302,7 +302,7 @@ class MockLDAP(object):
         try:
             entry = self.directory[dn]
         except KeyError:
-            raise ldap.NO_SUCH_OBJECT
+            raise self.NO_SUCH_OBJECT
 
         for item in mod_attrs:
             op, key, value = item
@@ -349,7 +349,7 @@ class MockLDAP(object):
         try:
             del self.directory[dn]
         except KeyError:
-            raise ldap.NO_SUCH_OBJECT
+            raise self.NO_SUCH_OBJECT
 
         return (107, [])
 
@@ -370,7 +370,7 @@ class MockLDAP(object):
         attrs = self.directory.get(base)
         print attrs
         if attrs is None:
-            raise ldap.NO_SUCH_OBJECT
+            raise self.NO_SUCH_OBJECT
 
         return [(base, attrs)]
 


### PR DESCRIPTION
Switched to self.NO_SUCH_OBJECT . 

Please pull.

Thanks,
       Marijn Vriens. 
