### PR TITLE
Replace pyldap dependency with python-ldap.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 extra = {}
-requirements = ['pyldap'],
-tests_require = ['nose', 'Mock', 'coverage', 'unittest2', 'pyldap']
+requirements = ['python-ldap'],
+tests_require = ['nose', 'Mock', 'coverage', 'unittest2', 'python-ldap']
 
 setup(
     name = "fakeldap",


### PR DESCRIPTION
pyldap was merged back into python-ldap in 3.0.0 and is now just a dummy
package whose only role is to require the new python-ldap.