### PR TITLE
Added unbind_s, search_ext and result3 support; changed rename_s to work how python-ldap does

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,136 @@
-.coverage
-cover
-dist
-build
-fakeldap.egg-info
-*.pyc
-.tox
-*.swp
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
 *.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+reports
+results.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# Development artifacts
+.python-version
+.DS_Store
+/*.sql
+config.codekit3
+sql/docker/mysql-data
+
+# Vim
+*.sw*
+*.bak
+tags
+
+# Terraform
+.terraform
+tags
+supervisord.pid
+requirements.txt.new
+
+# Ignore the config.codekit3 file -- it changes constantly
+config.codekit3
+
+# Ignore Visual Studio Code and PyCharm workspace and config
+*.code-workspace
+.idea
+.vscode
+
+# Local temp files
+local_storage
+

--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,13 @@ taken from Peter Sagerson's excellent django-auth-ldap_ module.
 Installation
 ============
 
-Get and install the code::
+To install from PyPI::
 
-    $ git clone git://github.com/30loops/fakeldap.git
+    $ pip install fakeldap
+
+To install via ``setup.py``::
+
+    $ git clone git://github.com/zulip/fakeldap.git
     $ cd fakeldap
     $ python setup.py install
 
@@ -34,14 +38,14 @@ Usage
 
     This code is still experimental and not very tested as of yet. So is the
     documentation
-    
+
 The ``MockLDAP`` class replaces the ``LDAPObject`` of the python-ldap module.
 The easiest way to use it, is to overwrite ``ldap.initialize`` to return
-``MockLDAP`` instead of ``LDAPObject``. The example below uses Michael Foord's
+``MockLDAP`` instead of ``LDAPObject``. The example below uses Python 3's
 Mock_ library to achieve that::
 
     import unittest
-    from mock import patch
+    from unittest.mock import patch
     from fakeldap import MockLDAP
 
 
@@ -60,13 +64,16 @@ Mock_ library to achieve that::
 
 The mock ldap object implements the following ldap operations:
 
-- simple_bind_s
-- search_s
-- compare_s
-- modify_s
-- delete_s
 - add_s
+- compare_s
+- delete_s
+- modify_s
 - rename_s
+- result3
+- search_ext
+- search_s
+- simple_bind_s
+- unbind_s
 
 This is an example how to use ``MockLDAP`` with fixed return values::
 
@@ -121,7 +128,7 @@ ldap server with a directory of entries::
                 "userPassword": "ldaptest"
         }
     }
-    mock_ldap = MockLDAP(tree) 
+    mock_ldap = MockLDAP(tree)
 
     record = [
         ('uid', 'crito'),

--- a/fakeldap.py
+++ b/fakeldap.py
@@ -332,6 +332,9 @@ class MockLDAP(object):
 
         return result
 
+    def unbind_s(self):
+        self._record_call('unbind_s', {})
+
     #
     # Internal implementations
     #

--- a/fakeldap.py
+++ b/fakeldap.py
@@ -25,13 +25,15 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from copy import deepcopy
 import re
 import sys
 import logging
 from collections import defaultdict
+import json
 import ldap
 from ldap.controls import SimplePagedResultsControl
-import json
+import pprint
 
 
 logger = logging.getLogger(__name__)
@@ -394,7 +396,7 @@ class MockLDAP(object):
 
     def _rename_s(self, dn, newrdn, superior=None):
         try:
-            entry = self.directory[dn]
+            entry = deepcopy(self.directory[dn])
         except KeyError:
             raise ldap.NO_SUCH_OBJECT
 

--- a/fakeldap.py
+++ b/fakeldap.py
@@ -504,6 +504,7 @@ class MockLDAP(object):
         return new_record
 
     def _record_call(self, api_name, arguments):
+        logger.info("CALL: api: %s, arguments: %s" % (api_name, arguments))
         self.calls.append((api_name, arguments))
 
     def _get_return_value(self, api_name, arguments):

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,10 @@
+# Development
+# ------------------------------------------------------------------------------
+autopep8==1.5                                 # https://github.com/hhatto/autopep8
+flake8==3.7.9                                 # https://github.com/PyCQA/flake8
+pycodestyle==2.5.0                            # https://github.com/PyCQA/pycodestyle
+mypy==0.701                                   # https://github.com/python/mypy
+
+# Testing
+# ------------------------------------------------------------------------------
+nose==1.3.7                                   # https://github.com/nose-devs/nose

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,17 @@
+[flake8]
+max-line-length: 120
+filename: *.py
+exclude: *.cfg, *.js, *.json, *.bak, *.md, *.sql, *.sh, *.txt, *.yml, simple_test_db, Makefile, Dockerfile, MANIFEST.in
+# E221:  multiple spaces before operator
+# E241:  multiple spaces after :
+# E265:  block comment should start with '# '
+# E266:  too many leading '#' for block comment
+# E401:  multiple imports on one line
+ignore = E221,E241,E265,E266,E401
+
+[mypy]
+python_executable: ~/.pyenv/shims/python
+
 [nosetests]
 with-coverage = true
 cover-package = fakeldap

--- a/setup.py
+++ b/setup.py
@@ -1,35 +1,44 @@
 from setuptools import setup, find_packages
 import os
-import sys
 
 from version import __version__
+
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+
 extra = {}
-requirements = ['python-ldap'],
-tests_require = ['nose', 'Mock', 'coverage', 'unittest2', 'python-ldap']
+requirements = [
+    'python-ldap'
+],
+tests_require = [
+    'nose',
+    'Mock',
+    'coverage',
+    'unittest2',
+    'python-ldap'
+]
 
 setup(
-    name = "fakeldap",
-    version = __version__,
-    #packages = find_packages('fakeldap'),
+    name="fakeldap",
+    version=__version__,
+    #packages=find_packages('fakeldap'),
     #include_package_data=True,
-    py_modules = ['fakeldap'],
-    install_requires = requirements,
+    py_modules=['fakeldap'],
+    install_requires=requirements,
 
     tests_require=tests_require,
     setup_requires='nose',
-    test_suite = "nose.collector",
+    test_suite="nose.collector",
     extras_require={'test': tests_require},
 
-    author = "Christo Buschek",
-    author_email = "crito@30loops.net",
-    url = "https://github.com/zulip/fakeldap",
-    description = "An implementation of a LDAPObject to fake a ldap server in unittests.",
-    long_description = read('README.rst'),
-    classifiers = [
+    author="Christo Buschek",
+    author_email="crito@30loops.net",
+    url="https://github.com/zulip/fakeldap",
+    description="An implementation of a LDAPObject to fake a ldap server in unittests.",
+    long_description=read('README.rst'),
+    classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
         'Intended Audience :: Developers',

--- a/tests.py
+++ b/tests.py
@@ -7,8 +7,8 @@ import unittest
 
 directory = {
     "cn=admin,dc=30loops,dc=net": {
-            "userPassword": "ldaptest"
-            }
+        "userPassword": "ldaptest"
+    }
 }
 
 
@@ -23,7 +23,7 @@ class TestLdapOperations(unittest.TestCase):
         """Try to bind a user."""
         # Make a valid bind
         eq_(
-            (97,[]),
+            (97, []),
             self.mock_ldap.simple_bind_s("cn=admin,dc=30loops,dc=net", "ldaptest")
         )
 
@@ -37,27 +37,27 @@ class TestLdapOperations(unittest.TestCase):
     def test_add_s_operation(self):
         """Test the addition of records to the mock ldap object."""
         record = [
-                ('uid', 'crito'),
-                ('userPassword', 'secret'),
-                ]
-        eq_((105,[],1,[]), self.mock_ldap.add_s(
-                    "uid=crito,ou=people,dc=30loops,dc=net", record
-                    ))
+            ('uid', 'crito'),
+            ('userPassword', 'secret'),
+        ]
+        eq_((105, [], 1, []), self.mock_ldap.add_s(
+            "uid=crito,ou=people,dc=30loops,dc=net", record
+        ))
 
         directory = {
-                "cn=admin,dc=30loops,dc=net": {"userPassword": "ldaptest"},
-                "uid=crito,ou=people,dc=30loops,dc=net": {
-                    "uid": "crito", "userPassword": "secret"}
-                }
+            "cn=admin,dc=30loops,dc=net": {"userPassword": "ldaptest"},
+            "uid=crito,ou=people,dc=30loops,dc=net": {
+                "uid": "crito", "userPassword": "secret"}
+        }
         eq_(directory, self.mock_ldap.directory)
 
         record = [
-                ('uid', 'bas'),
-                ('userPassword', 'secret'),
-                ]
-        eq_((105,[],2,[]), self.mock_ldap.add_s(
-                    "uid=bas,ou=people,dc=30loops,dc=net", record
-                    ))
+            ('uid', 'bas'),
+            ('userPassword', 'secret'),
+        ]
+        eq_((105, [], 2, []), self.mock_ldap.add_s(
+            "uid=bas,ou=people,dc=30loops,dc=net", record
+        ))
 
     def test_search_s_base(self):
         result = self.mock_ldap.search_s("cn=admin,dc=30loops,dc=net", ldap.SCOPE_BASE)
@@ -65,41 +65,50 @@ class TestLdapOperations(unittest.TestCase):
 
     def test_search_s_onelevel(self):
         directory = {
-            "ou=users,dc=30loops,dc=net": { "ou": "users" },
+            "ou=users,dc=30loops,dc=net": {"ou": "users"},
             "cn=admin,ou=users,dc=30loops,dc=net": {
-                    "userPassword": "ldaptest"
-                    },
+                "userPassword": "ldaptest"
+            },
             "cn=john,ou=users,dc=30loops,dc=net": {
-                    "userPassword": "ldaptest",
-                    "mail": "john@example.com"
-                    },
+                "userPassword": "ldaptest",
+                "mail": "john@example.com"
+            },
             "cn=jack,ou=users,dc=30loops,dc=net": {
-                    # test [value, ] format here
-                    "userPassword": ["ldaptest", ],
-                    "mail": ["jack@example.com", ]
-                    },
+                # test [value, ] format here
+                "userPassword": ["ldaptest", ],
+                "mail": ["jack@example.com", ]
+            },
             "cn=john2,ou=users,dc=30loops,dc=net": {
-                    "userPassword": "ldaptest",
-                    "mail": "john@example.com"  # same mail as john
-                    }
+                "userPassword": "ldaptest",
+                "mail": "john@example.com"  # same mail as john
+            }
         }
         self.mock_ldap = MockLDAP(directory)
 
-        result = self.mock_ldap.search_s("dc=30loops,dc=net", ldap.SCOPE_ONELEVEL,
-                                         "(mail=jack@example.com)")
+        result = self.mock_ldap.search_s(
+            "dc=30loops,dc=net",
+            ldap.SCOPE_ONELEVEL,
+            "(mail=jack@example.com)"
+        )
         # The search is one-level, so the above should return no results:
         self.assertEqual(result, [])
 
-        result = self.mock_ldap.search_s("ou=users,dc=30loops,dc=net", ldap.SCOPE_ONELEVEL,
-                                         "(mail=jack@example.com)")
+        result = self.mock_ldap.search_s(
+            "ou=users,dc=30loops,dc=net",
+            ldap.SCOPE_ONELEVEL,
+            "(mail=jack@example.com)"
+        )
         self.assertEqual(
             result,
             [('cn=jack,ou=users,dc=30loops,dc=net',
-             {'userPassword': ['ldaptest'], 'mail': ['jack@example.com']})]
+              {'userPassword': ['ldaptest'], 'mail': ['jack@example.com']})]
         )
 
-        result = self.mock_ldap.search_s("ou=users,dc=30loops,dc=net", ldap.SCOPE_ONELEVEL,
-                                         "(mail=john@example.com)")
+        result = self.mock_ldap.search_s(
+            "ou=users,dc=30loops,dc=net",
+            ldap.SCOPE_ONELEVEL,
+            "(mail=john@example.com)"
+        )
         self.assertEqual(len(result), 2)
         self.assertIn(
             ('cn=john,ou=users,dc=30loops,dc=net', {'userPassword': 'ldaptest', 'mail': 'john@example.com'}),
@@ -111,5 +120,5 @@ class TestLdapOperations(unittest.TestCase):
         )
 
         result = self.mock_ldap.search_s("dc=30loops,dc=net", ldap.SCOPE_ONELEVEL,
-                                          "(mail=nonexistant@example.com)")
+                                         "(mail=nonexistant@example.com)")
         self.assertEqual(result, [])


### PR DESCRIPTION
Hello

Thank you for your fakeldap module!   

I've added a few things that we needed in order to test our code, and also did some PEP8 fixes to make my linter happy.

* Added unbind_s support
* Added search_ext and result3 support
* Changed rename_s to work how python-ldap expects: rename_s(dn, newrdn, superior)
* When using the argument list as a dict key, serialize the argument list with a bytes-aware JSON encoder.  This fixes the "list is unhashable" , "bytes are unhashable", etc. problems

best wishes
Chris