### PR TITLE
Fix reference to wrong repo in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Installation
 
 Get and install the code::
 
-    $ git clone git://github.com/30loops/fakeldap.git
+    $ git clone git://github.com/zulip/fakeldap.git
     $ cd fakeldap
     $ python setup.py install
 


### PR DESCRIPTION
The repo is now `zulip/fakeldap`, so that instruction is outdated and incorrect