### PR TITLE
setup.cfg: Specify that this package should be a universal wheel.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ cover-html = true
 cover-erase = true
 cover-inclusive = true
 nocapture=1
+
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
`python3 -m build` will only build a Python 3 wheel distribution
unless otherwise indicated in setup.cfg. Since this package has
support for both Python 2 and 3, we should create a universal
wheel when generating wheels.
